### PR TITLE
1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.2
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.17.2
 
 # Mod Properties
-mod_version=mc1.21.7-1.0.4-fabric
+mod_version=mc1.21.8-1.0.5-fabric
 maven_group=dev.sterner
 archives_base_name=guardvillagers
 
 # Dependencies
-fabric_version=0.129.0+1.21.7
+fabric_version=0.133.0+1.21.8
 midnightlib_version=1.7.5+1.21.6-fabric

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,9 +26,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.17.2",
-    "minecraft": "1.21.7",
+    "minecraft": "1.21.8",
     "java": ">=21",
-    "fabric-api": ">=0.128.2+1.21.7"
+    "fabric-api": ">=0.133.0+1.21.8"
   },
   "suggests": {
     "another-mod": "*"


### PR DESCRIPTION
Purpose of this PR is to bump to minecraft version 1.21.8 from 1.21.7.

Note: no code changes in this bump.