### PR TITLE
1.21.7 - Fix Armor Rendering

### DIFF
--- a/src/main/java/dev/sterner/guardvillagers/client/model/GuardVillagerModel.java
+++ b/src/main/java/dev/sterner/guardvillagers/client/model/GuardVillagerModel.java
@@ -3,6 +3,9 @@ package dev.sterner.guardvillagers.client.model;
 import dev.sterner.guardvillagers.client.render.state.GuardBipedRenderState;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.BowItem;
+import net.minecraft.item.CrossbowItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Arm;
 import net.minecraft.util.Hand;
@@ -34,8 +37,8 @@ public class GuardVillagerModel extends BipedEntityModel<GuardBipedRenderState> 
                 ModelTransform.origin(-5.0F, 2.0F, 0.0F));
         ModelPartData leftArm = partdefinition.addChild("left_arm", ModelPartBuilder.create().uv(33, 48)
                 .cuboid(-1.0F, -2.0F, -2.0F, 4, 12, 4, new Dilation(0.0F)), ModelTransform.origin(5.0F, 2.0F, 0.0F));
-        torso.addChild("quiver", ModelPartBuilder.create().uv(100, 0).cuboid(-2.5F, -2.0F, 0.0F, 5, 10, 5,
-                new Dilation(0.0F)), ModelTransform.origin(0.5F, 3.0F, 2.3F));
+        torso.addChild("quiver", ModelPartBuilder.create().uv(100, 0).cuboid(-2.5F, -2.0F, 0.0F, 5, 9, 5,
+                new Dilation(0.0F)), ModelTransform.origin(0.5F, 3.8F, 2.3F));
         head.addChild("nose",
                 ModelPartBuilder.create().uv(54, 0).cuboid(-1.0F, 0.0F, -2.0F, 2, 4, 2, new Dilation(0.0F)),
                 ModelTransform.origin(0.0F, -3.0F, -4.0F));
@@ -44,10 +47,10 @@ public class GuardVillagerModel extends BipedEntityModel<GuardBipedRenderState> 
         partdefinition.addChild("left_leg", ModelPartBuilder.create().uv(16, 28).cuboid(-2.0F, 0.0F, -2.0F,
                 4, 12, 4, new Dilation(0.0F)), ModelTransform.origin(1.9F, 12.0F, 0.0F));
         leftArm.addChild("shoulderPad_right",
-                ModelPartBuilder.create().uv(72, 33).mirrored().cuboid(0.0F, 0.0F, -3.0F, 5, 3, 6, new Dilation(0.0F)),
+                ModelPartBuilder.create().uv(72, 33).mirrored().cuboid(0.1F, 0.23F, -3.0F, 5, 3, 6, new Dilation(0.0F)),
                 ModelTransform.origin(-0.5F, -3.5F, 0.0F));
         rightArm.addChild("shoulderPad_left",
-                ModelPartBuilder.create().uv(72, 33).cuboid(-5.0F, 0.0F, -3.0F, 5, 3, 6, new Dilation(0.0F)),
+                ModelPartBuilder.create().uv(72, 33).cuboid(-5.1F, 0.23F, -3.0F, 5, 3, 6, new Dilation(0.0F)),
                 ModelTransform.origin(0.5F, -3.5F, 0.0F));
         head.addChild("hat", ModelPartBuilder.create().uv(0, 0).cuboid(-4.5F, -11.0F, -4.5F, 9,
                 11, 9, new Dilation(0.0F)), ModelTransform.origin(0.0F, 0.0F, 0.0F));
@@ -81,6 +84,20 @@ public class GuardVillagerModel extends BipedEntityModel<GuardBipedRenderState> 
             this.eatingAnimationRightHand(Hand.OFF_HAND, state, ageInTicks);
             this.eatingAnimationLeftHand(Hand.MAIN_HAND, state, ageInTicks);
         }
+
+        ArmLShoulderPad.roll = -0.34906585F;
+        ArmRShoulderPad.roll =  0.34906585F;
+        quiver.roll = 0.2617993877991494F;
+
+        boolean wearingChest = !state.equippedChestStack.isEmpty();
+        ArmLShoulderPad.visible = !wearingChest;
+        ArmRShoulderPad.visible = !wearingChest;
+
+        if (wearingChest) {
+            quiver.originZ = 3.01F;
+        }
+
+        this.quiver.visible = state.hasRangedWeapon;
     }
 
     public void eatingAnimationRightHand(Hand hand, GuardBipedRenderState state, float ageInTicks) {

--- a/src/main/java/dev/sterner/guardvillagers/client/render/state/GuardBipedRenderState.java
+++ b/src/main/java/dev/sterner/guardvillagers/client/render/state/GuardBipedRenderState.java
@@ -6,6 +6,7 @@ import net.minecraft.util.Hand;
 
 public class GuardBipedRenderState extends BipedEntityRenderState {
     public int kickTicks;
+    public boolean hasRangedWeapon;
 
     // add this so we can choose the texture without the entity
     public int guardVariant;

--- a/src/main/java/dev/sterner/guardvillagers/client/renderer/GuardRenderer.java
+++ b/src/main/java/dev/sterner/guardvillagers/client/renderer/GuardRenderer.java
@@ -82,12 +82,14 @@ public class GuardRenderer extends BipedEntityRenderer<
         state.mainArm = entity.getMainArm();
 
         // Populate hand stacks so the arm-pose logic can use them
-        ItemStack main = entity.getMainHandStack();
-        ItemStack off  = entity.getOffHandStack();
+        state.mainHandStack = entity.getMainHandStack();
+        state.offHandStack  = entity.getOffHandStack();
+
+        state.hasRangedWeapon = isRanged(state.mainHandStack) || isRanged(state.offHandStack);
 
         // Compute arm poses (used to be assigned on the model; now they go on the state)
-        BipedEntityModel.ArmPose mainPose = getArmPose(entity, main, off, Hand.MAIN_HAND);
-        BipedEntityModel.ArmPose offPose  = getArmPose(entity, main, off, Hand.OFF_HAND);
+        BipedEntityModel.ArmPose mainPose = getArmPose(entity, state.mainHandStack, state.offHandStack, Hand.MAIN_HAND);
+        BipedEntityModel.ArmPose offPose  = getArmPose(entity, state.mainHandStack, state.offHandStack, Hand.OFF_HAND);
 
         if (state.mainArm == Arm.RIGHT) {
             state.rightArmPose = mainPose;
@@ -96,6 +98,12 @@ public class GuardRenderer extends BipedEntityRenderer<
             state.rightArmPose = offPose;
             state.leftArmPose  = mainPose;
         }
+    }
+
+    private static boolean isRanged(ItemStack s) {
+        if (s == null || s.isEmpty()) return false;
+        var it = s.getItem();
+        return (it instanceof net.minecraft.item.BowItem) || (it instanceof net.minecraft.item.CrossbowItem);
     }
 
     private BipedEntityModel.ArmPose getArmPose(GuardEntity entityIn, ItemStack itemStackMain, ItemStack itemStackOff, Hand handIn) {


### PR DESCRIPTION
Purpose of this PR is to fix the armor rendering handling on 1.21.7. This is done to match closer to the [original version of this repo by mrsterner](https://github.com/mrsterner/GuardVillagers).

Updates to shoulder pads:
-  no longer show through chest armor
- slightly rotated downward to match original version

Updates to quiver:
- updated quivers to match the slight offset on the back as found in the original version
- no longer intrudes into the head.
- now sit off of chest armor slightly more to prevent armor rendering into the quiver.
- size was slightly reduced. 
- only renders if not holding a bow or a crossbow